### PR TITLE
Remove ConfigHelper Trait

### DIFF
--- a/src/Traits/HasManyNotes.php
+++ b/src/Traits/HasManyNotes.php
@@ -15,13 +15,6 @@ use Illuminate\Database\Eloquent\Model;
 trait HasManyNotes
 {
     /* -----------------------------------------------------------------
-     |  Traits
-     | -----------------------------------------------------------------
-     */
-
-    use ConfigHelper;
-
-    /* -----------------------------------------------------------------
      |  Relationships
      | -----------------------------------------------------------------
      */
@@ -33,7 +26,7 @@ trait HasManyNotes
      */
     public function notes()
     {
-        return $this->morphMany($this->getModelFromConfig('notes'), 'noteable');
+        return $this->morphMany(config('notes.notes.model'), 'noteable');
     }
 
     /* -----------------------------------------------------------------

--- a/src/Traits/HasOneNote.php
+++ b/src/Traits/HasOneNote.php
@@ -15,13 +15,6 @@ use Illuminate\Database\Eloquent\Model;
 trait HasOneNote
 {
     /* -----------------------------------------------------------------
-     |  Traits
-     | -----------------------------------------------------------------
-     */
-
-    use ConfigHelper;
-
-    /* -----------------------------------------------------------------
      |  Relationships
      | -----------------------------------------------------------------
      */
@@ -33,7 +26,7 @@ trait HasOneNote
      */
     public function note()
     {
-        return $this->morphOne($this->getModelFromConfig('notes'), 'noteable');
+        return $this->morphOne(config('notes.notes.model'), 'noteable');
     }
 
     /* -----------------------------------------------------------------


### PR DESCRIPTION
This PR removes the `ConfigHelper` Trait from the `HasManyNotes` and `HasOneNote` Traits.

This is "required", because it causes PHP errors, if the `ConfigHelper` trait is added "multiple times" to one model.