### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php":               ">=7.0",
-        "arcanedev/support": "~4.0"
+        "arcanedev/support": "~4.2"
     },
     "require-dev": {
         "orchestra/testbench": "~3.5.0",


### PR DESCRIPTION
You need to require 4.2 because in 4.0 you don't have all the files required.
`Class 'Arcanedev\Support\Database\Model' not found`