### PR TITLE
Fix documentation links

### DIFF
--- a/_docs/1.Installation-and-Setup.md
+++ b/_docs/1.Installation-and-Setup.md
@@ -2,9 +2,9 @@
 
 ## Table of contents
 
-  1. [Installation and Setup](1-Installation-and-Setup.md)
-  2. [Configuration](2-Configuration.md)
-  3. [Usage](3-Usage.md)
+  1. [Installation and Setup](1.Installation-and-Setup.md)
+  2. [Configuration](2.Configuration.md)
+  3. [Usage](3.Usage.md)
 
 ## Server Requirements
 

--- a/_docs/2.Configuration.md
+++ b/_docs/2.Configuration.md
@@ -2,11 +2,11 @@
 
 ## Table of contents
 
-  1. [Installation and Setup](1-Installation-and-Setup.md)
-  2. [Configuration](2-Configuration.md)
-  3. [Usage](3-Usage.md)
+  1. [Installation and Setup](1.Installation-and-Setup.md)
+  2. [Configuration](2.Configuration.md)
+  3. [Usage](3.Usage.md)
 
-You can customize the package by editing the `config/notes.php` config file: 
+You can customize the package by editing the `config/notes.php` config file:
 
 ```php
 <?php

--- a/_docs/3.Usage.md
+++ b/_docs/3.Usage.md
@@ -2,9 +2,9 @@
 
 ## Table of contents
 
-  1. [Installation and Setup](1-Installation-and-Setup.md)
-  2. [Configuration](2-Configuration.md)
-  3. [Usage](3-Usage.md)
+  1. [Installation and Setup](1.Installation-and-Setup.md)
+  2. [Configuration](2.Configuration.md)
+  3. [Usage](3.Usage.md)
 
 First things first, edit your eloquent model by using the `Arcanedev\LaravelNotes\Traits\HasManyNotes` trait.
 
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model {
     use HasManyNotes;
-    
+
     // Other stuff ...
 }
 ```
@@ -31,9 +31,9 @@ You can call the `createNote()` method on your Eloquent model like below:
 $post = App\Post::first();
 $note = $post->createNote('Hello world #1');
 ```
- 
+
 #### Add With a Author/ User
- 
+
 ```php
 $user = App\User::first();
 $post = App\Post::first();
@@ -50,9 +50,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model {
     use HasManyNotes;
-    
+
     // Other stuff ...
-    
+
     /**
      * Get the current author's id.
      *
@@ -66,16 +66,16 @@ class Post extends Model {
 ```
 
 #### Getting Notes
- 
+
 ```php
 $post  = App\Post::first();
 $notes = $post->notes;
 ```
- 
+
 > **NOTE :** `$post->notes` relation property is only available in the `HasManyNotes` trait. If you're using `HasOneNote` trait, use `$post->note` instead.    
 
-#### Getting the author's notes 
- 
+#### Getting the author's notes
+
 You can also retrieve all the author's notes by using the `Arcanedev\LaravelNotes\Traits\AuthoredNotes` Trait in your User model (for example).
 
 ```php


### PR DESCRIPTION
Links on documentation doesn't work.
This also does some whitespace cleanup.