### PR TITLE
Respect $table and $connection properties when extending Note model

### DIFF
--- a/src/Models/AbstractModel.php
+++ b/src/Models/AbstractModel.php
@@ -24,7 +24,11 @@ abstract class AbstractModel extends Model
     {
         parent::__construct($attributes);
 
-        $this->setConnection(config('notes.database.connection'));
+        if (is_null($this->connection))
+        {
+            $this->setConnection(config('notes.database.connection'));
+        }
+        
         $this->setPrefix(config('notes.database.prefix'));
     }
 }

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -63,7 +63,11 @@ class Note extends AbstractModel
     {
         parent::__construct($attributes);
 
-        $this->setTable(config('notes.notes.table', 'notes'));
+        if (is_null($this->table))
+        {
+            $this->setTable(config('notes.notes.table', 'notes'));
+        }
+
     }
 
     /* -----------------------------------------------------------------


### PR DESCRIPTION
Respect model properties when extending `Arcanedev\LaravelNotes\Models\Note` like this:

```php
class MyNote extends Arcanedev\LaravelNotes\Models\Note
{

    protected $table = 'my-table';

    protected $connection = 'my-connection';

}
```