### PR TITLE
Update composer.json to support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type":    "library",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8",
         "arcanedev/support": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Problem 1
    - arcanedev/laravel-notes 8.0.0 requires php ^7.3 -> your PHP version (8.0.0rc1) does not satisfy that requirement.
    - arcanedev/laravel-notes 8.0.0 requires php ^7.3 -> your PHP version (8.0.0rc1) does not satisfy that requirement.
    - Installation request for arcanedev/laravel-notes ^8.0 -> satisfiable by arcanedev/laravel-notes[8.0.0].