### PR TITLE
Look for notes table config under the correct config key

### DIFF
--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -75,11 +75,13 @@ class Note extends PrefixedModel
     {
         parent::__construct($attributes);
 
-        $config = config('notes.database', []);
+        $config = config('notes', []);
+        $databaseConfig = Arr::get($config, 'database', []);
+        $notesConfig = Arr::get($config, 'notes', []);
 
-        $this->setConnection(Arr::get($config, 'connection'));
-        $this->setPrefix(Arr::get($config, 'prefix'));
-        $this->setTable(Arr::get($config, 'table', 'notes'));
+        $this->setConnection(Arr::get($databaseConfig, 'connection'));
+        $this->setPrefix(Arr::get($databaseConfig, 'prefix'));
+        $this->setTable(Arr::get($notesConfig, 'table', 'notes'));
     }
 
     /* -----------------------------------------------------------------


### PR DESCRIPTION
Somewhere between version 5 and 9 src/Models/Note.php stopped looking for the notes table name at `notes.notes.table` and instead expected it to be at `notes.database.table`.

This PR changes the constructor to get the config from the original place.

Tests pass. No additional tests added.